### PR TITLE
KIALI-1185 Fix namespace fetching and error message on login page

### DIFF
--- a/src/actions/LoginThunkActions.ts
+++ b/src/actions/LoginThunkActions.ts
@@ -45,8 +45,8 @@ const loginSuccess = async (dispatch: KialiDispatch, session: LoginSession) => {
 // The `data` argument is defined as `any` because the dispatchers receive
 // different kinds of data (such as e-mail/password, tokens).
 const performLogin = (dispatch: KialiDispatch, state: KialiAppState, data?: any) => {
-  const bail = (error: Login.LoginResult) =>
-    data ? dispatch(LoginActions.loginFailure(error)) : dispatch(LoginActions.logoutSuccess());
+  const bail = (loginResult: Login.LoginResult) =>
+    data ? dispatch(LoginActions.loginFailure(loginResult.error)) : dispatch(LoginActions.logoutSuccess());
 
   Dispatcher.prepare().then((result: AuthResult) => {
     if (result === AuthResult.CONTINUE) {

--- a/src/actions/NamespaceThunkActions.ts
+++ b/src/actions/NamespaceThunkActions.ts
@@ -3,6 +3,7 @@ import { KialiAppState } from '../store/Store';
 import * as Api from '../services/Api';
 import { KialiAppAction } from './KialiAppAction';
 import { NamespaceActions } from './NamespaceAction';
+import { authenticationToken } from '../utils/AuthenticationToken';
 
 const shouldFetchNamespaces = (state: KialiAppState) => {
   if (!state) {
@@ -39,7 +40,7 @@ const NamespaceThunkActions = {
         }
 
         // Dispatch a thunk from thunk!
-        return dispatch(NamespaceThunkActions.asyncFetchNamespaces(state.session.token));
+        return dispatch(NamespaceThunkActions.asyncFetchNamespaces(authenticationToken(getState())));
       } else {
         // Let the calling code know there's nothing to wait for.
         return Promise.resolve();

--- a/src/containers/LoginPageContainer.ts
+++ b/src/containers/LoginPageContainer.ts
@@ -7,7 +7,7 @@ import LoginThunkActions from '../actions/LoginThunkActions';
 
 const mapStateToProps = (state: KialiAppState) => ({
   status: state.authentication.status,
-  error: state.authentication.error
+  message: state.authentication.message
 });
 
 const mapDispatchToProps = (dispatch: ThunkDispatch<KialiAppState, void, KialiAppAction>) => ({

--- a/src/pages/Login/LoginPage.tsx
+++ b/src/pages/Login/LoginPage.tsx
@@ -72,7 +72,7 @@ export default class LoginPage extends React.Component<LoginProps, LoginState> {
                 <Col sm={10} smOffset={1} md={8} mdOffset={2} lg={8} lgOffset={2}>
                   <div className={'card-pf'}>
                     <header className={'login-pf-header'} />
-                    {this.props.error && <Alert>{this.props.error}</Alert>}
+                    {this.props.status === LoginStatus.error && <Alert>{this.props.message}</Alert>}
                     <Form onSubmit={e => this.handleSubmit(e)} id={'kiali-login'}>
                       <FormGroup>
                         <FormControl

--- a/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
+++ b/src/pages/Login/__tests__/__snapshots__/LoginPage.test.tsx.snap
@@ -631,7 +631,7 @@ ShallowWrapper {
                       <header
                         className="login-pf-header"
                       />,
-                      undefined,
+                      false,
                       <Form
                         bsClass="form"
                         componentClass="form"
@@ -700,7 +700,7 @@ ShallowWrapper {
                       "rendered": null,
                       "type": "header",
                     },
-                    undefined,
+                    false,
                     Object {
                       "instance": null,
                       "key": undefined,
@@ -1509,7 +1509,7 @@ ShallowWrapper {
                         <header
                           className="login-pf-header"
                         />,
-                        undefined,
+                        false,
                         <Form
                           bsClass="form"
                           componentClass="form"
@@ -1578,7 +1578,7 @@ ShallowWrapper {
                         "rendered": null,
                         "type": "header",
                       },
-                      undefined,
+                      false,
                       Object {
                         "instance": null,
                         "key": undefined,

--- a/src/reducers/LoginState.ts
+++ b/src/reducers/LoginState.ts
@@ -8,7 +8,7 @@ import { LoginActions } from '../actions/LoginActions';
 export const INITIAL_LOGIN_STATE: LoginStateInterface = {
   status: LoginStatus.loggedOut,
   session: undefined,
-
+  message: '',
   // We define a small expiration date for the UI so it does not block the
   // session handling on login.
   uiExpiresOn: moment()

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -79,7 +79,7 @@ export interface LoginSession {
 export interface LoginState {
   status: LoginStatus;
   session?: LoginSession;
-  error?: any;
+  message: string;
   uiExpiresOn: RawDate;
 }
 


### PR DESCRIPTION
Fixes an issue where the namespace list couldn't be fetched anymore from the dropdown.

Fixes an issue where error messages on the normal (eg non-oauth) login page wouldn't be shown.
